### PR TITLE
use custom docker file

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -60,8 +60,12 @@ under the License.
     <fileSet filtered="true" packaged="false">
       <directory>src/main/resources</directory>
     </fileSet>
+    <fileSet filtered="true" packaged="false">
+      <directory>src/main/docker</directory>
+    </fileSet>
     <fileSet filtered="true" packaged="true">
       <directory>src/test/java</directory>
     </fileSet>
+
   </fileSets>
 </archetype-descriptor>

--- a/src/main/resources/archetype-resources/src/main/docker/Dockerfile
+++ b/src/main/resources/archetype-resources/src/main/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3 as base
+RUN apk add  --no-cache openjdk@package.java-version@
+RUN jlink \
+--module-path /opt/java/jmods \
+--compress=2 \
+--add-modules java.se,jdk.unsupported,jdk.crypto.ec \
+--no-header-files \
+--no-man-pages \
+--output /opt/jdk-mini
+FROM alpine:3
+COPY --from=base /opt/jdk-mini /opt/jdk-mini
+RUN apk add  --no-cache coreutils
+ENV JAVA_HOME=/opt/jdk-mini
+ENV PATH="$PATH:$JAVA_HOME/bin"
+COPY etc/ /etc/${microserviceName}/
+ADD resources/* /data/
+RUN chmod +x /data/entrypoint.sh
+ENTRYPOINT /data/entrypoint.sh

--- a/src/main/resources/archetype-resources/src/main/docker/Dockerfile
+++ b/src/main/resources/archetype-resources/src/main/docker/Dockerfile
@@ -14,5 +14,4 @@ ENV JAVA_HOME=/opt/jdk-mini
 ENV PATH="$PATH:$JAVA_HOME/bin"
 COPY etc/ /etc/${microserviceName}/
 ADD resources/* /data/
-RUN chmod +x /data/entrypoint.sh
-ENTRYPOINT /data/entrypoint.sh
+ENTRYPOINT ["java", "-jar", "/data/@package.name@.jar"]


### PR DESCRIPTION
Create a smaller docker container with jdk-mini, using custom docker file from [Cyril Poder]
https://tech.forums.softwareag.com/t/migrate-java-microservices-from-java-8-to-java-11/242978
